### PR TITLE
Restrict sensitive settings to admins on API

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -759,6 +759,21 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 		else:
 			self.connection_state_str = gettext("No token given.")
 
+	def on_settings_load(self):
+		data = octoprint.plugin.SettingsPlugin.on_settings_load(self)
+
+		# only return our restricted settings to admin users - this is only needed for OctoPrint <= 1.2.16
+		restricted = ("token", "tracking_token")
+		for r in restricted:
+			if r in data and (current_user is None or current_user.is_anonymous() or not current_user.is_admin()):
+				data[r] = None
+
+		return data
+
+	def get_settings_restricted_paths(self):
+		# only used in OctoPrint versions > 1.2.16
+		return dict(admin=[["token"], ["tracking_token"]])
+
 ##########
 ### Softwareupdate API
 ##########

--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -3,6 +3,7 @@ from PIL import Image
 import threading, requests, re, time, datetime, StringIO, json, random, logging, traceback, io, collections, os, flask,base64,PIL
 import octoprint.plugin, octoprint.util, octoprint.filemanager
 from flask.ext.babel import gettext
+from flask.ext.login import current_user
 from .telegramCommands import TCMD # telegramCommands.
 from .telegramNotifications import TMSG # telegramNotifications
 from .telegramNotifications import telegramMsgDict # dict of known notification messages


### PR DESCRIPTION
I recently noticed that I'd not properly protected some sensitive data in one of my own plugins. An API key was available on the settings API for basically everyone with access to the instance in question (settings API GET requests are not restricted since a lot of settings data is directly needed in the frontend for various things). Not a good idea. So I fixed that in my own plugin, added a new utility method in OctoPrint itself in future versions to allow to define restricted settings paths (already part of 1.2.17rc1) and thought I'd also go around and send some PRs to the plugins I know of that also might have sensitive data such as API keys and what not stored in their settings.

This PR is the result of that. I gave it a quick test whirl and it seems that it works. I noticed an exception on the GET SimpleAPI (undefined `commandDict`), however as far as I could see that was unrelated to my changes.

The basic idea is to set sensitive settings fields to "None" if the settings load call does not originate from a user with admin rights. You might also want to do this for the `chats` settings, I'm not sure though and limited myself to the tokens for now.

Two implementations are provided, one for OctoPrint versions up to and including 1.2.16, and one for OctoPrint versions after 1.2.16 which come with a new method on the SettingsPlugin API to allow defining restricted paths.