### PR TITLE
`chats` must be provided as dict on settings

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -762,7 +762,7 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 		data = octoprint.plugin.SettingsPlugin.on_settings_load(self)
 
 		# only return our restricted settings to admin users - this is only needed for OctoPrint <= 1.2.16
-		restricted = (("token", None), ("tracking_token", None), ("chats", dict())
+		restricted = (("token", None), ("tracking_token", None), ("chats", dict()))
 		for r, v in restricted:
 			if r in data and (current_user is None or current_user.is_anonymous() or not current_user.is_admin()):
 				data[r] = v

--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -762,10 +762,10 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 		data = octoprint.plugin.SettingsPlugin.on_settings_load(self)
 
 		# only return our restricted settings to admin users - this is only needed for OctoPrint <= 1.2.16
-		restricted = ("token", "tracking_token", "chats")
-		for r in restricted:
+		restricted = (("token", None), ("tracking_token", None), ("chats", dict())
+		for r, v in restricted:
 			if r in data and (current_user is None or current_user.is_anonymous() or not current_user.is_admin()):
-				data[r] = None
+				data[r] = v
 
 		return data
 


### PR DESCRIPTION
Otherwise, if anonymously loaded first, bindings will be
generated differently, causing subsequent binding errors
when accessing `chats`.

See foosel/OctoPrint#1567 for related discussion