### PR TITLE
Fix for issue #44 (new settings behaviour in OctoPrint 1.3.0)

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -717,19 +717,19 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 
 
 	def on_settings_save(self, data):
-		delList = []
 		# Remove 'new'-flag and apply bindings for all chats
-		if data['chats']:
+		if 'chats' in data and data['chats']:
+			delList = []
 			for key in data['chats']:
 				if 'new' in data['chats'][key] or 'new' in data['chats'][key]:
 					data['chats'][key]['new'] = False
 				# Look for deleted chats
 				if not key in self.chats and not key == "zBOTTOMOFCHATS":
 					delList.append(key)
-		# Delete chats finally
-		for key in delList:
-			del data['chats'][key]
-		# Also remove 'new'-flag from self.chats so settingsUI is consistent 
+			# Delete chats finally
+			for key in delList:
+				del data['chats'][key]
+		# Also remove 'new'-flag from self.chats so settingsUI is consistent
 		# self.chats will only update to settings data on first received message after saving done
 		for key in self.chats:
 			if 'new' in self.chats[key]:
@@ -737,26 +737,28 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 
 		self._logger.debug("Saving data: " + str(data))
 		# Check token for right format
-		data['token'] = data['token'].strip()
-		if not re.match("^[0-9]+:[a-zA-Z0-9_\-]+$", data['token']):
-			self._logger.error("Not saving token because it doesn't seem to have the right format.")
-			self.connection_state_str = gettext("The previously entered token doesn't seem to have the correct format. It should look like this: 12345678:AbCdEfGhIjKlMnOpZhGtDsrgkjkZTCHJKkzvjhb")
-			data['token'] = ""
+		if 'token' in data:
+			data['token'] = data['token'].strip()
+			if not re.match("^[0-9]+:[a-zA-Z0-9_\-]+$", data['token']):
+				self._logger.error("Not saving token because it doesn't seem to have the right format.")
+				self.connection_state_str = gettext("The previously entered token doesn't seem to have the correct format. It should look like this: 12345678:AbCdEfGhIjKlMnOpZhGtDsrgkjkZTCHJKkzvjhb")
+				data['token'] = ""
 		old_token = self._settings.get(["token"])
 		# Update Tracking
-		if not data['tracking_activated']:
+		if 'tracking_activated' in data and not data['tracking_activated']:
 			data['tracking_token'] = None
 		# Now save settings
 		octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
 		self.set_log_level()
 		# Reconnect on new token
 		# Will stop listener on invalid token
-		if data['token']!=old_token:
-			self.stop_listening()
-		if data['token']!="":
-			self.start_listening()
-		else:
-			self.connection_state_str = gettext("No token given.")
+		if 'token' in data:
+			if data['token']!=old_token:
+				self.stop_listening()
+			if data['token']!="":
+				self.start_listening()
+			else:
+				self.connection_state_str = gettext("No token given.")
 
 	def on_settings_load(self):
 		data = octoprint.plugin.SettingsPlugin.on_settings_load(self)


### PR DESCRIPTION
Only attempt to access such keys in the provided settings that
are actually there and in the frontend manually persist chats
as received from own plugin endpoint to global settings
endpoint in order to trigger on_settings_save processing.

This is a bit dirty but basically emulates what the click on
Save in the settings dialog used to do (I think - I have to admit
I was a bit confused by the whole back-and-forth). After completion
of the new save call it's actually no longer necessary to explicitly
click Save on the Settings dialog, but it was completely unclear
to me how to properly set the new status for a newly added chat
without that roundtrip.

Tested against 1.2.18, 1.3.0rc2 and current `devel` branch of
OctoPrint by deleting existing configuration and going through
full setup routine, then running a test print and checking if
I was notified at the end as configured. Appears to have worked,
got my notifications and also replies to any commands I sent
as expected. You still should give it a critical review because I
might have overlooked something in bot handling that I simply
don't know but would be obvious for someone familiar with 
telegram bots.

Should solve #44 