### PR TITLE
Relative URL in snapshot

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -8,6 +8,7 @@ from .telegramCommands import TCMD # telegramCommands.
 from .telegramNotifications import TMSG # telegramNotifications
 from .telegramNotifications import telegramMsgDict # dict of known notification messages
 from .emojiDict import telegramEmojiDict # dict of known emojis
+import urlparse # to detect if a url is absolute
 ####################################################
 #        TelegramListener Thread Class
 # Connects to Telegram and will listen for messages.
@@ -1137,6 +1138,8 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 
 	def take_image(self):
 		snapshot_url = self._settings.global_get(["webcam", "snapshot"])
+		if not urlparse.urlparse(snapshot_url).netloc: # is not absolute
+		    snapshot_url = "http://localhost/" + snapshot_url # to absolute
 		self._logger.debug("Snapshot URL: " + str(snapshot_url))
 		data = None
 		if snapshot_url:


### PR DESCRIPTION
I am using octoprint with a relative url in snapshot.
For example snapshot_url="webcam/?action=snapshot"
Although octoprint work with this configuration, Octoprint-Telegram send me "[ERR GET IMAGE]".
This patch converts a relative url to an absolute url.