### PR TITLE
Issue #146 - Rotate 90 should be 270

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -1156,7 +1156,7 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 			if flipV:
 				image = image.transpose(Image.FLIP_TOP_BOTTOM)
 			if rotate:
-				image = image.transpose(Image.ROTATE_90)
+				image = image.transpose(Image.ROTATE_270)
 			output = StringIO.StringIO()
 			image.save(output, format="JPEG")
 			data = output.getvalue()


### PR DESCRIPTION
Rotation of image should be COUNTER clockwise. Right now it's rotating 90 clockwise, so i'm changing that to 270 clockwise (i.e. 90 counter clockwise).