### PR TITLE
Fixed image mirroring

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -1313,9 +1313,9 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 		self._logger.debug("Image transformations [H:%s, V:%s, R:%s]", flipH, flipV, rotate)
 		if flipH or flipV or rotate:
 			image = Image.open(StringIO.StringIO(data))
-			if flipH:
+			if not flipH:
 				image = image.transpose(Image.FLIP_LEFT_RIGHT)
-			if flipV:
+			if not flipV:
 				image = image.transpose(Image.FLIP_TOP_BOTTOM)
 			if rotate:
 				image = image.transpose(Image.ROTATE_270)


### PR DESCRIPTION
The mirroring was the inverse of what expected.

As per issue #146, I really don't know if it's PIL that's causing the issue or Octoprint, but with this fix the behaviour is at least coherent.