### PR TITLE
Add silent message option (no active notification for choosen events)

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -1083,7 +1083,7 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 		except Exception as ex:
 			self._logger.debug("Caught an exception in _send_edit_msg(): " + str(ex))
 
-	def _send_msg(self, message="", with_image=False,with_gif=False,responses=None, delay=0, inline = True, chatID = "", markup=None, showWeb=False, **kwargs):
+	def _send_msg(self, message="", with_image=False,with_gif=False,responses=None, delay=0, inline = True, chatID = "", markup=None, showWeb=False, silent=False, **kwargs):
 		if not self.send_messages:
 			return
 
@@ -1121,6 +1121,7 @@ class TelegramPlugin(octoprint.plugin.EventHandlerPlugin,
 
 			image_data = None
 			data['chat_id'] = chatID
+			data['disable_notification'] = silent
 			if with_gif : #giloser 05/05/19
 				try:
 					self._logger.info("Will try to create a gif ")

--- a/octoprint_telegram/static/js/telegram.js
+++ b/octoprint_telegram/static/js/telegram.js
@@ -134,6 +134,20 @@ $(function() {
                     hideMup = "";
                     hideComb = "display:none"
                 }
+
+                if(self.settings.settings.plugins.telegram.messages[keys[id]].silent()) {
+                  imgSilent = "volume-off";
+                  bSilent = "warning";
+                  txtSilent = "Silent";
+                  hideMup = "";
+                  hideComb = "";
+                } else{
+                  imgSilent = "volume-up";
+                  bSilent = "success";
+                  txtSilent = "Notification";
+                  hideMup = "";
+                  hideComb = ""
+                }
                 if(self.settings.settings.plugins.telegram.messages[keys[id]].gif()){
                     imgGif = "camera";
                     bGif = "success";
@@ -200,6 +214,12 @@ $(function() {
                 btnImg += '<i id="chkImg'+self.msgCnt+'" class="icon-'+img+'"></i> ';
                 btnImg += '<span id="chkTxt'+self.msgCnt+'">'+txt+'</span></label><br>';
 
+                var btnSilent = '<span class="muted"><small>Send silently?<br></small></span>';
+                btnSilent += '<label id="chkSilentBtn'+self.msgCnt+'" class="btn btn-'+bSilent+' btn-mini" title="Toggle \'Silence\'">';
+                btnSilent += '<input type="checkbox" style="display:none" data-bind="checked: settings.settings.plugins.telegram.messages.'+keys[id]+'.silent, click: toggleSilent(\''+self.msgCnt+'\')"/>';
+                btnSilent += '<i id="chkSilent'+self.msgCnt+'" class="icon-'+imgSilent+'"></i> ';
+                btnSilent += '<span id="chkSilentTxt'+self.msgCnt+'">'+txtSilent+'</span></label><br>';
+
                 var btnGif = '<span class="muted" id="chkGifLbl'+self.msgCnt+'" style="' + showGif + '" ><small>Send with gif?<br></small></span>';
                 btnGif += '<label id="chkGifBtn'+self.msgCnt+'"  style="' + showGif + '" class="btn btn-'+bGif+' btn-mini" title="Toggle \'Send with gif\'">';
                 btnGif += '<input type="checkbox" style="display:none" data-bind="checked: settings.settings.plugins.telegram.messages.'+keys[id]+'.gif, click: toggleGif(\''+self.msgCnt+'\')"/>';
@@ -217,7 +237,7 @@ $(function() {
                     msgEdt += '<div class="controls " >';
                         msgEdt += '<div class="row">';
                             msgEdt += '<div class="span9"><textarea rows="4" style="margin-left:7px;" class="block" data-bind="value: settings.settings.plugins.telegram.messages.'+keys[id]+'.text"></textarea></div>';
-                            msgEdt += '<div class="span3" style="text-align:center;">' + btnImg + btnGif + btnSecMsg +  btnGrp + '</div>';
+                            msgEdt += '<div class="span3" style="text-align:center;">' + btnImg + btnGif + btnSecMsg + btnSilent + btnGrp + '</div>';
                         msgEdt += '</div></div></div>';
 
                 $('#telegram_msg_list').append(msgEdt);
@@ -295,6 +315,19 @@ $(function() {
                 }
             }
         }
+
+        self.toggleSilent = function(data){
+          if(!self.onBindLoad){
+              $('#chkSilent'+data).toggleClass("icon-volume-off icon-volume-up");
+              $('#chkSilentBtn'+data).toggleClass("btn-success btn-warning");
+              if($('#chkSilentTxt'+data).text()==="Silent"){
+                  $('#chkSilentTxt'+data).text("Notification");
+              }
+              else{
+                  $('#chkSilentTxt'+data).text("Silent");
+              }
+          }
+      }
 
         self.toggleGif = function(data){
             if(!self.onBindLoad){

--- a/octoprint_telegram/telegramNotifications.py
+++ b/octoprint_telegram/telegramNotifications.py
@@ -14,6 +14,7 @@ telegramMsgDict = {
 			'PrinterStart': {
 				'text': "{emo:rocket} " + gettext("Hello. I'm online and ready to receive your commands."),
 				'image': False,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -21,6 +22,7 @@ telegramMsgDict = {
 			'PrinterShutdown': {
 				'text': "{emo:octopus} {emo:shutdown} " + gettext("Shutting down. Goodbye."),
 				'image': False,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -28,6 +30,7 @@ telegramMsgDict = {
 			'PrintStarted': {
 				'text': gettext("Started printing {file}."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -35,6 +38,7 @@ telegramMsgDict = {
 			'PrintPaused': {
 				'text': gettext("Paused printing {file} at {percent}%%. {time_left} remaining."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -42,6 +46,7 @@ telegramMsgDict = {
 			'PrintResumed': {
 				'text': gettext("Resumed printing {file} at {percent}%%. {time_left} remaining."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -49,6 +54,7 @@ telegramMsgDict = {
 			'PrintFailed': {
 				'text': gettext("Printing {file} failed."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -56,6 +62,7 @@ telegramMsgDict = {
 			'ZChange': {
 				'text': gettext("Printing at Z={z}.\nBed {bed_temp}/{bed_target}, Extruder {e1_temp}/{e1_target}.\n{time_done}, {percent}%% done, {time_left} remaining.\nCompleted time {time_finish}."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -63,6 +70,7 @@ telegramMsgDict = {
 			'PrintDone': {
 				'text': gettext("Finished printing {file}."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off"
@@ -70,6 +78,7 @@ telegramMsgDict = {
 			'StatusNotPrinting': {
 				'text': gettext("Not printing.\nBed {bed_temp}/{bed_target}, Extruder {e1_temp}/{e1_target}."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined' : True,
 				'markup': "off",
@@ -82,6 +91,7 @@ telegramMsgDict = {
 			'plugin_pause_for_user_event_notify': {
 				'text': "{emo:warning} " + gettext("User interaction required.\nBed {bed_temp}/{bed_target}, Extruder {e1_temp}/{e1_target}."),
 				'image': True,
+				'silent': False,
 				'gif': False,
 				'combined': True,
 				'markup': "off"
@@ -189,6 +199,7 @@ class TMSG():
 			kwargs['with_gif'] = self.main._settings.get(['messages',str(kwargs['event']),'gif']) #giloser 05/05/19
 		else:
 			kwargs['with_gif'] = 0
+		kwargs['silent'] = self.main._settings.get(['messages',str(kwargs['event']),'silent']) #babs
 
 		self._logger.debug("Printer Status" + str(status))
 		# define locals for string formatting

--- a/octoprint_telegram/templates/telegram_settings.jinja2
+++ b/octoprint_telegram/templates/telegram_settings.jinja2
@@ -158,6 +158,17 @@
                <span class="help-block"><small>Send image with "Not connected" status message?</small></span>
 		</div>
 	</div>
+
+	<div class="control-group">
+		<label class="control-label">{{ _('"Not connected"-status') }}</label>
+		<div class="controls">
+                <label id="chkSilentBtn0" class="btn btn-mini" title="Toggle 'Silence'">
+                <input type="checkbox" style="display:none" data-bind="checked: settings.settings.plugins.telegram.image_not_connected, click: toggleSilent('0')"/>
+                <i id="chkSilentImg0" class=""></i>
+               <span id="chkSilentTxt0"></span></label>
+               <span class="help-block"><small>Notification</small></span>
+		</div>
+	</div>
 	 
 	<!--div class="control-group">
 		<label class="control-label">{{ _('"Not connected"-status') }}</label>


### PR DESCRIPTION
This feature allows some events to be sent without notification to the device.

Eg:  allowing Z layer change message be received without notification (still have message, image, gif etc) while keeping start, stop failed with notification, sound and so on.

