### PR TITLE
Fix use of deprecated flask.ext imports

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -3,8 +3,8 @@ from PIL import Image
 from subprocess import Popen, PIPE
 import threading, requests, re, time, datetime, StringIO, json, random, logging, traceback, io, collections, os, flask,base64,PIL, pkg_resources,subprocess,zipfile,glob #,resource
 import octoprint.plugin, octoprint.util, octoprint.filemanager
-from flask.ext.babel import gettext
-from flask.ext.login import current_user
+from flask_babel import gettext
+from flask_login import current_user
 from .telegramCommands import TCMD # telegramCommands.
 from .telegramNotifications import TMSG # telegramNotifications
 from .telegramNotifications import telegramMsgDict # dict of known notification messages

--- a/octoprint_telegram/telegramCommands.py
+++ b/octoprint_telegram/telegramCommands.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 import logging, sarge, hashlib, datetime, time, operator, socket
 import octoprint.filemanager
 import requests
-from flask.ext.babel import gettext
+from flask_babel import gettext
 from .telegramNotifications import telegramMsgDict
 
 ################################################################################################################

--- a/octoprint_telegram/telegramNotifications.py
+++ b/octoprint_telegram/telegramNotifications.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import time, datetime, logging
 import octoprint.util
-from flask.ext.babel import gettext
+from flask_babel import gettext
 
 ###################################################################################################
 # Here you find the known notification messages and their handles.


### PR DESCRIPTION
`flask.ext` has been deprecated [for years now](https://github.com/pallets/flask/issues/1135) and should actually have been logging [a warning](https://github.com/pallets/flask/blob/0.12.x/flask/exthook.py#L69) to console ever since too. OctoPrint 1.4.1 had to update the flask dependencies due to security considerations and in the new flask version the old compatibility layer still allowing `flask.ext` to work got removed.

Which means this plugin no longer will load on OctoPrint 1.4.1+ unless this PR gets merged and a new release (1.5.1?) pushed out.

See also the discussion in OctoPrint/OctoPrint#3638

Closes #269