### PR TITLE
Check settings values to be the valid numbers

### DIFF
--- a/octoprint_telegram/static/js/telegram.js
+++ b/octoprint_telegram/static/js/telegram.js
@@ -541,6 +541,26 @@ $(function() {
             
         }
 
+        self.isNumber = function(number) {
+            return !isNaN(parseFloat(number)) && isFinite(number);
+        }
+
+        self.onSettingsBeforeSave = function() {
+	        // Check specific settings to be a number, not a null
+	        // In case it's not a number set it to be 0
+            var settings = self.settings.settings.plugins.telegram;
+            var settings_to_check_number = [
+                settings.notification_height,
+                settings.notification_time,
+                settings.message_at_print_done_delay
+            ];
+            for (var i = 0; i < settings_to_check_number.length; i++) {
+                if (!self.isNumber(settings_to_check_number[i]())) {
+                    settings_to_check_number[i](0);
+                }
+            }
+        }
+
         self.onServerDisconnect = function(){
             clearTimeout(self.reloadPending);
         }


### PR DESCRIPTION
How to reproduce a problem:
**1**. Open octoprint's settings and go to `Telegram`'s parts.
**2**. Find `Notification settings` and remove any values from the inputs. Like so:
![image](https://user-images.githubusercontent.com/7851779/95684121-fdee1b80-0bf7-11eb-897f-d8827b56b883.png)
**3**. Save settings
**4**. Call `/settings` command in telegram bot.
**5**. Bot won't response you anything and you can find this error in log messages:
```
2020-10-11 18:59:24,781 - octoprint.plugins.telegram.listener - ERROR - Exception caught! must be real number, not NoneType
Traceback (most recent call last):
  File "/home/szobov/dev/OctoPrint-Telegram/octoprint_telegram/__init__.py", line 81, in loop
    self.processMessage(message)
  File "/home/szobov/dev/OctoPrint-Telegram/octoprint_telegram/__init__.py", line 116, in processMessage
    self.handleTextMessage(message, chat_id, from_id)
  File "/home/szobov/dev/OctoPrint-Telegram/octoprint_telegram/__init__.py", line 305, in handleTextMessage
    self.main.tcmd.commandDict[command]['cmd'](chat_id,from_id,command,parameter)
  File "/home/szobov/dev/OctoPrint-Telegram/octoprint_telegram/telegramCommands.py", line 242, in cmdSettings
    time=self.main._settings.get_int(["notification_time"]))
  File "/home/szobov/dev/OctoPrint-Telegram/venv3/lib/python3.6/site-packages/flask_babel/__init__.py", line 550, in gettext
    return string if not variables else string % variables
TypeError: must be real number, not NoneType
```


Changes from this PR will fix this behaviour by checking all settings, that should be the numbers to be numbers, not `null`.
So, in case you'll remove the value and click on `save` button it will substitute all `null`s with `0`.