### PR TITLE
Add octolapse support, send video

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -1809,6 +1809,8 @@ class TelegramPlugin(
             if with_gif:  # giloser 05/05/19
                 try:
                     sendOneInLoop = False
+                    if kwargs["event"] == "plugin_octolapse_movie_done":
+                        kwargs["event"] = "MovieDone"
                     if kwargs["event"] == "MovieDone":
                         ret = kwargs["movie"]
                         # file = self._file_manager.path_on_disk(octoprint.filemanager.FileDestinations.LOCAL, ret)
@@ -1893,8 +1895,8 @@ class TelegramPlugin(
                             ret = self.create_gif_new(chatID, 0, 0)
 
                     if ret != "" and not sendOneInLoop:
-                        self._logger.debug("send_file whith message: " + str(ret))
-                        self.send_file(chatID, ret, message)
+                        self._logger.debug("send_video with message: " + str(ret))
+                        self.send_video(chatID, ret, message)
                         # ret = self.create_gif_new(chatID,0,0)
                         # if ret != "":
                         # 	self.send_file(chatID, ret,message)
@@ -2256,7 +2258,7 @@ class TelegramPlugin(
         except Exception as ex:
             pass
 
-    def send_video(self, message, video_file):
+    def send_video(self, chatID, video_file, message):
         if not self.send_messages:
             return
 
@@ -2264,7 +2266,7 @@ class TelegramPlugin(
         r = requests.post(
             self.bot_url + "/sendVideo",
             files=files,
-            data={"chat_id": self._settings.get(["chat"]), "caption": message},
+            data={"chat_id": chatID, "caption": message},
             proxies=self.getProxies(),
         )
         self._logger.debug(

--- a/octoprint_telegram/telegramNotifications.py
+++ b/octoprint_telegram/telegramNotifications.py
@@ -99,6 +99,7 @@ telegramMsgDict = {
         "no_setting": True,
     },
     "StatusPrinting": {"bind_msg": "ZChange", "no_setting": True},
+    "plugin_octolapse_movie_done": {"bind_msg": "MovieDone", "no_setting": True},
     "plugin_pause_for_user_event_notify": {
         "text": "{emo:warning} "
         + gettext(
@@ -232,6 +233,7 @@ class TMSG:
             "gCode_M600": self.msgColorChangeRequested,
             "Error": self.msgPrinterError,
             "MovieDone": self.msgMovieDone,
+            "plugin_octolapse_movie_done": self.msgMovieDone,
             "UserNotif": self.msgUserNotif,
             "Connected": self.msgConnected,
             "Disconnected": self.msgConnected,
@@ -280,6 +282,8 @@ class TMSG:
         self._sendNotification(payload, **kwargs)
 
     def msgMovieDone(self, payload, **kwargs):
+        if kwargs["event"] == "plugin_octolapse_movie_done":
+            kwargs["event"] == "MovieDone"
         self._sendNotification(payload, **kwargs)
 
     def msgPrinterError(self, payload, **kwargs):
@@ -423,6 +427,8 @@ class TMSG:
                 self._logger.exception("Exception on getting thumbnail: " + str(ex))
 
             try:
+                if event == "plugin_octolapse_movie_done":
+                    event = "MovieDone"
                 if event == "MovieDone":
                     if "movie" in payload:
                         kwargs["movie"] = payload["movie"]
@@ -469,6 +475,7 @@ class TMSG:
                     + "'."
                 )
             self._logger.debug("Sending Notification: " + message)
+            self._logger.debug(kwargs)
             # Do we want to send with Markup?
             kwargs["markup"] = self.main._settings.get(
                 ["messages", kwargs["event"], "markup"]


### PR DESCRIPTION
This pull request adds support for the plugin_octolapse_movie_done event, generated by Octolapse. In addition, timelapse files are now sent in video format and not in file format, improving the user experience.
Closes #369 and #370 .