### PR TITLE
fix snapshot url for multicam plugin

### DIFF
--- a/octoprint_telegram/__init__.py
+++ b/octoprint_telegram/__init__.py
@@ -1982,31 +1982,37 @@ class TelegramPlugin(
                                 self._logger.debug("multicam_profiles : " + str(curr))
                                 for li in curr:
                                     try:
-                                        self._logger.debug(
-                                            "multicam profile:  " + str(li)
-                                        )
-                                        snapshot_url = li.get("URL")
+                                        snapshot_url = li.get("snapshot") # try to get the snapshot url
                                         self._logger.debug(
                                             "multicam url :  " + str(snapshot_url)
                                         )
-
-                                        defsnap = self._settings.global_get(
-                                            ["webcam", "snapshot"]
-                                        )
-                                        defstream = self._settings.global_get(
-                                            ["webcam", "stream"]
-                                        )
-                                        streamname = defstream.rsplit("/", 1).pop()
-                                        snapname = defsnap.rsplit("/", 1).pop()
-                                        if streamname in snapshot_url:
+                                        
+                                        if not snapshot_url: # if snapshot url is not stored try to create it
                                             self._logger.debug(
-                                                str(streamname)
-                                                + " found so should be replaced by "
-                                                + str(snapname)
+                                                "multicam profile:  " + str(li)
                                             )
-                                            snapshot_url = snapshot_url.replace(
-                                                streamname, snapname
+                                            snapshot_url = li.get("URL")
+                                            self._logger.debug(
+                                                "multicam url :  " + str(snapshot_url)
                                             )
+
+                                            defsnap = self._settings.global_get(
+                                                ["webcam", "snapshot"]
+                                            )
+                                            defstream = self._settings.global_get(
+                                                ["webcam", "stream"]
+                                            )
+                                            streamname = defstream.rsplit("/", 1).pop()
+                                            snapname = defsnap.rsplit("/", 1).pop()
+                                            if streamname in snapshot_url:
+                                                self._logger.debug(
+                                                    str(streamname)
+                                                    + " found so should be replaced by "
+                                                    + str(snapname)
+                                                )
+                                                snapshot_url = snapshot_url.replace(
+                                                    streamname, snapname
+                                                )
 
                                         self._logger.debug(
                                             "Snapshot URL: " + str(snapshot_url)


### PR DESCRIPTION
The [multicam plugin](https://github.com/mikedmor/OctoPrint_MultiCam) now supports defining a snapshot url.
This means we should try to read this user defined url instead of deriving the url from the stream url.
I changed it in a way to first try to read the "snapshot" value and use as a snapshot url. Should this value be empty it will default to the old method. 

I had an issues with an ESP32cam since the url for the snapshot is not the same format as for a mjpg streamer cam. I'm simply not able to use the cam with this plugin since it ignores the snapshot url defined in the mulitcam plugin. 
This will also be fixed with this PR.

Andi