### PR TITLE
fix notification sent twice bug when printing with octolapse (#13)

### DIFF
--- a/octoprint_telegram/telegramNotifications.py
+++ b/octoprint_telegram/telegramNotifications.py
@@ -516,7 +516,7 @@ class TMSG:
                 return True
         zdiff = self.main._settings.get_float(["notification_height"])
         if zdiff and zdiff > 0.0:
-            if old_z is None:
+            if old_z is None or new_z < 0:
                 return False
             # check the zdiff
             if abs(new_z - (old_z or 0.0)) >= 1.0:


### PR DESCRIPTION
When printing with the [Octolapse](https://plugins.octoprint.org/plugins/octolapse/) plugin enabled, the [`msgZChange`](https://github.com/fabianonline/OctoPrint-Telegram/blob/b1f90950293575005d3be4d791602a662222a366/octoprint_telegram/telegramNotifications.py#L126C6-L126C16) and so the [`is_notification_necessary`](https://github.com/fabianonline/OctoPrint-Telegram/blob/b1f90950293575005d3be4d791602a662222a366/octoprint_telegram/telegramNotifications.py#L225C6-L225C31) routine is executed twice, resulting in a double notification sent by OctoPrint-Telegram. As checks to prevent sending a notification when the new Z value is negative was missing, this pull request aim to both fix the bug mentioned in #13 (the part regarding Octolapse) and adding this data consistency check.
This will not fix the whole bug, as the maintainer reported in the aforementioned issue, the instruction [`new_z < self.last_z`](https://github.com/fabianonline/OctoPrint-Telegram/blob/b1f90950293575005d3be4d791602a662222a366/octoprint_telegram/telegramNotifications.py#L241C36-L241C59) may be removed, but I defer to his judgment.