### PR TITLE
Remove destinations keyword #424

### DIFF
--- a/octoprint_telegram/telegramCommands.py
+++ b/octoprint_telegram/telegramCommands.py
@@ -2793,7 +2793,7 @@ class TCMD:
             path = "/".join(fullPath.split("/")[1:])
             self._logger.debug("fileList path : " + str(path))
             fileList = self.main._file_manager.list_files(
-                path=path, destinations=dest, recursive=False
+                path=path, recursive=False
             )
             files = fileList[dest]
             arrayD = []


### PR DESCRIPTION
Fixes #424, tested against latest OctoPrint, did not test against older versions 

You can test by installing:
https://github.com/guysoft/OctoPrint-Telegram/archive/refs/heads/bugfix/424.zip